### PR TITLE
Texture invalidation issue and deprecated class fix

### DIFF
--- a/CreatureRenderer.cpp
+++ b/CreatureRenderer.cpp
@@ -48,7 +48,7 @@ namespace CreatureRenderer {
     
     Renderer::Renderer(CreatureModule::CreatureManager * manager_in,
                        cocos2d::Texture2D * texture_in)
-    : manager(manager_in), texture(texture_in), debug_draw(false)
+    : manager(manager_in), texture(nullptr), debug_draw(false)
     {
         setGLProgram(cocos2d::GLProgramCache::getInstance()->getGLProgram(cocos2d::GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
         setTexture(texture_in);
@@ -57,7 +57,10 @@ namespace CreatureRenderer {
     
     Renderer::~Renderer()
     {
-        
+        if (texture)
+        {
+            CC_SAFE_RELEASE_NULL(texture);
+        }
     }
     
     void

--- a/CreatureRenderer.cpp
+++ b/CreatureRenderer.cpp
@@ -50,7 +50,8 @@ namespace CreatureRenderer {
                        cocos2d::Texture2D * texture_in)
     : manager(manager_in), texture(texture_in), debug_draw(false)
     {
-        setGLProgram(cocos2d::ShaderCache::getInstance()->getGLProgram(cocos2d::GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
+        setGLProgram(cocos2d::GLProgramCache::getInstance()->getGLProgram(cocos2d::GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
+        setTexture(texture_in);
         scheduleUpdate();
     }
     
@@ -156,6 +157,15 @@ namespace CreatureRenderer {
 		metadata = std::make_unique<CreatureModule::CreatureMetaData>(str_stream.str());
 		meta_indices.resize(manager->GetCreature()->GetTotalNumIndices());
 	}
+    
+    void Renderer::setTexture(cocos2d::Texture2D* texture_in)
+    {
+        if (texture != texture_in) {
+            CC_SAFE_RELEASE(texture);
+            CC_SAFE_RETAIN(texture_in);
+            texture = texture_in;
+        }
+    }
     
     void
     Renderer::SetDebugDraw(bool flag_in)

--- a/CreatureRenderer.h
+++ b/CreatureRenderer.h
@@ -57,6 +57,8 @@ namespace CreatureRenderer {
         
         virtual const cocos2d::BlendFunc& getBlendFunc () const;
         
+        void setTexture(cocos2d::Texture2D * texture_in);
+	    
         void SetDebugDraw(bool flag_in);
         
         std::pair<glm::vec2, glm::vec2> GetCharacterBounds();


### PR DESCRIPTION
ShaderCache is deprecated, so it is replaced with GLProgramCache.

Also, there is an issue with the texture being used by the CreatureRenderer.  Once the CreatureRenderer is created with a texture, it doesn't call retain() on that texture, so the texture can be freed at any time in the cocos2d-x engine, since it doesn't know that an object is still using it.   Without  this fix, in some scenarios the texture gets deleted, and results in a black image being displayed in place of the actual texture.

The fix is to safely retain and release the texture when it is no longer used.